### PR TITLE
[TASK] Replace outdated links in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -63,13 +63,13 @@ Here is an overview of the essential resources to help you find the correct info
 ## Getting Started
 TYPO3 has the most extensive and thorough [documentation](https://docs.typo3.org), making it easy to get started with the CMS.
 
-- [System Requirements](https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/SystemRequirements/Index.html) <br />
+- [System Requirements](https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/SystemRequirements/Index.html) <br />
 System requirements for the host operation system, including its web server and database and how they should be configured prior to installation.
-- [Installation Guide](https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Installation/Index.html) <br />
+- [Installation Guide](https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Installation/Index.html) <br />
   The installation chapter provides detailed instructions about how to install TYPO3, it also contains information about how to deploy TYPO3 to a production environment.
-- [Setup](https://docs.typo3.org/m/typo3/tutorial-getting-started/11.5/en-us/Setup/Index.html) <br />
+- [Setup](https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Setup/Index.html) <br />
 Setup aims to guide you through the next steps post installation. Such as adding domains, setting up additional users and configuring languages.
-- [Troubleshooting](https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/Troubleshooting/Index.html) <br />
+- [Troubleshooting](https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/Troubleshooting/Index.html) <br />
   Troubleshoot common issues that can occur during installation. The Troubleshooting chapter covers both TYPO3 CMS and the host environment including the web server, database and PHP.
 
 
@@ -84,10 +84,10 @@ The best and easiest way to get in touch with the TYPO3 community and get help i
 
 Thank you for considering contributing to the TYPO3 Project! The contribution guide can be found in the [TYPO3 documentation](https://docs.typo3.org/Home/Contribute.html).
 
-- TYPO3 [Core](https://docs.typo3.org/m/typo3/guide-contributionworkflow/master/en-us/)
-- TYPO3 [Documentation](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocsOfficial/Index.html)
-- [Coding Guidelines](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/CodingGuidelines/Index.html)
-- Other TYPO3 [projects](https://docs.typo3.org/m/typo3/team-t3oteam/master/en-us/)
+- TYPO3 [Core](https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/)
+- TYPO3 [Documentation](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocsOfficial/Index.html)
+- [Coding Guidelines](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/CodingGuidelines/Index.html)
+- Other TYPO3 [projects](https://docs.typo3.org/m/typo3/team-t3oteam/main/en-us/)
 
 ## Community Values
 


### PR DESCRIPTION
The README.md has been adjusted for the TYPO3 v12
release. However, this file contained links to older
version links to different documentation areas.

This change uses 12.4 links instead of 11.5 or 10.4
in links and also adopts the `master` to `main` branch
renaming.